### PR TITLE
#22: Remove caching from lambda authorizer

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -29,6 +29,9 @@ Resources:
         Authorizers:
           LambdaAuthorizer:
             FunctionArn: !GetAtt LambdaAuthorizerFunction.Arn
+            Identity:
+              ValidationExpression: Bearer.*
+              ReauthorizeEvery: 0
   #### USER RELATED RESOURCES ####
   GetUserFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
- Prevents 403 issues with lambda authorizer