### PR TITLE
#8: Reenable caching for 10 mins

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -31,7 +31,7 @@ Resources:
             FunctionArn: !GetAtt LambdaAuthorizerFunction.Arn
             Identity:
               ValidationExpression: Bearer.*
-              ReauthorizeEvery: 0
+              ReauthorizeEvery: 600
   #### USER RELATED RESOURCES ####
   GetUserFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
No need to disable caching, just need to flush the cache if lambda authorizer gets triggered without JWT Secret set, and response is cached